### PR TITLE
Update to 1.4.20

### DIFF
--- a/com.qzandronum.Q-Zandronum.appdata.xml
+++ b/com.qzandronum.Q-Zandronum.appdata.xml
@@ -47,6 +47,35 @@
   </screenshots>
 
   <releases>
+  <release version="1.4.20" date="2024-11-28">
+      <description>
+        <p>Update Q-Zandronum to 1.4.20</p>
+        <ul>
+          <li>Bots no longer fire their weapons in warmup state..</li>
+          <li>You can no longer switch to spectator in singleplayer campaign unless sv_cheats is ON.</li>
+          <li>Fixed user4 dash not working when jump button is pressed.</li>
+          <li>Fixed midi soundfont default path and the fallback path.</li>
+          <li>Fixed LumpOpen ACS function crash (thanks TDRR).Backported the latest SetPlayerClass ACS function code from Zandronum 3.2.</li>
+          <li>Backported the Floor_Stop() and Ceiling_Stop() ACS functions from GZDoom.</li>
+          <li>Fixed botepisode support and made it possible to create PvP campaigns with HUB levels. See below changes for details.</li>
+          <li>Botepisode campaigns (PvP botmatch) are now displayed on top of PvE campaigns in episodes list.</li>
+          <li>Leaving PvP gamemode campaign level now displays intermission.</li>
+          <li>The ACS_Execute, ACS_ExecuteAlways and Teleport_NewMap functions now support string map names. Make sure to add a minus before the map name. For example: Teleport_NewMap(-"MAP02").</li>
+          <li>Added campaignhub property to MAPINFO lump. It is supposed to be used in singleplayer botepisode campaigns to tell the deathmatch map where to go after the match has ended.</li>
+          <li>Added botsSkillOffset property to CMPGNINF lump to offset bot skills up or down per each level individually.</li>
+          <li>Added GAMEEVENT_MAP_COMPLETE event type (index 8) for EVENT scripts. This event is triggered after returning to HUB from a deathmatch match, and it's arguments provider the map name and info on whether the player won or not.</li>
+          <li>Added support for setting custom cvars in CMPGNINF lump. The syntax is cvar cvarname = value.</li>
+          <li>Added InCampaign() ACS function to tell whether the player is currently in a campaign.</li>
+          <li>The map console command will no longer start a campaign if launching a campaign map. It has to be done via the "New Game" menu.</li>
+          <li>FreeformMenu consinders singleplayer botmatch as singleplayer when using NotInSingleplayer flag.</li>
+          <li>FreeformMenu only consinders PvP gamemodes as botmatch when using NotInBotplay flag.</li>
+          <li>Fixed parsing player and bot team info in CMPGNINF lump.</li>
+          <li>Fixed Respawn map scripts not running for players that respawned after map change.</li>
+          <li>Fixed some cvars not setting correctly when set by CMPGNINF lump.</li>
+          <li>Fixed botmatch campaign status not saving correctly in saved games.</li>
+	</ul>
+      </description>
+  </release>	
   <release version="1.4.19" date="2024-09-26">
       <description>
         <p>Update Q-Zandronum to 1.4.19</p>

--- a/com.qzandronum.Q-Zandronum.yaml
+++ b/com.qzandronum.Q-Zandronum.yaml
@@ -112,7 +112,7 @@ modules:
   - name: q-zandronum
     buildsystem: simple
     build-commands:
-      - tar -xf Q-Zandronum_*_Linux_amd64.tar.gz
+      - tar -xf Q-Zandronum_*_Linux_amd64.gz
       - install -D q-zandronum /app/bin/q-zandronum
       - install -D q-zandronum-server /app/bin/q-zandronum-server
       - install -D q-zandronum.pk3 /app/share/games/doom/q-zandronum.pk3

--- a/com.qzandronum.Q-Zandronum.yaml
+++ b/com.qzandronum.Q-Zandronum.yaml
@@ -42,8 +42,8 @@ modules:
       - -DCMAKE_INSTALL_LIBDIR=/app/lib
     sources:
       - type: archive
-        url: https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/2.1.3.tar.gz
-        sha256: dbda0c685942aa3ea908496592491e5ec8160d2cf1ec9d5fd5470e50768e7859
+        url: https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/3.0.4.tar.gz
+        sha256: 0270f9496ad6d69e743f1e7b9e3e9398f5b4d606b6a47744df4b73df50f62e38
 
   - name: fluidsynth1
     buildsystem: cmake-ninja
@@ -91,8 +91,8 @@ modules:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
     sources:
       - type: archive
-        url: https://bitbucket.org/Doomseeker/doomseeker/get/1.4.1.tar.bz2
-        sha256: 3983434ebea6aa5dab69d031dddd00caa062407c4e7f688ead47094fcde47dc5
+        url: https://bitbucket.org/Doomseeker/doomseeker/get/1.5.1.tar.bz2
+        sha256: eb9c0e2cd4dc1218b6712e451e76ddde963156e9cf79dd23bbd059ce3d807d81
       - type: shell
         commands:
           # Package requires HG_ details for version numbers
@@ -119,13 +119,13 @@ modules:
       - install -D libfmodex64-4.44.64.so /app/lib/libfmodex64-4.44.64.so
     sources:
       - type: file
-        url: https://github.com/IgeNiaI/Q-Zandronum/releases/download/1.4.19/Q-Zandronum_1.4.19_Linux_amd64.tar.gz
-        sha256: 2a7656b319aa85a92637cd7f93dbdf342bc421861bbd8d63db2d7b5e0ac3e8d8
+        url: https://github.com/IgeNiaI/Q-Zandronum/releases/download/1.4.20/Q-Zandronum_1.4.20_Linux_amd64.gz
+        sha256: de7e9c61a5b6d1237deb419e9fc4f33162446752a28eda6c17a236df9939530a
         x-checker-data:
           type: json
           url: https://api.github.com/repos/IgeNiaI/Q-Zandronum/releases/latest
           version-query: .tag_name
-          url-query: .assets[] | select(.browser_download_url | contains("Linux_amd64.tar.gz"))
+          url-query: .assets[] | select(.browser_download_url | contains("Linux_amd64.gz"))
             | .browser_download_url
 
   - name: launcher
@@ -144,8 +144,8 @@ modules:
       - type: file
         path: com.qzandronum.Q-Zandronum.128.png
       - type: file
-        url: https://github.com/coelckers/gzdoom/raw/g4.8.2/soundfont/gzdoom.sf2
-        sha256: fca3e514b635a21789d4224e84865d2954a2a914d46b64aa8219ddb565c44869
+        url: https://github.com/coelckers/gzdoom/raw/g4.13.2/soundfont/gzdoom.sf2
+        sha256: a9058609b07c1f0e0c1f420e76c2e80ba78136e6173e836caab51ffb13e552f1
       - type: script
         dest-filename: doomseeker.sh
         commands:


### PR DESCRIPTION
Updated dependencies : 
- Updated Q-Zandronum to version 1.4.20
- Doomseeker to 1.5.1
- libjpeg-turbo to 3.0.4
- GZDoom soundfile from the g4.13.2 release

Also updated the changelog to add 1.4.20.

It is my first time, contributing to a flatpak and haven't tested it __yet__. I didn't really check whether all the dependencies changes gave improvements or were even useful to update (For example, the GzDoom one, which, I assume, is different since the checksum is, but no idea if it changed anything).

I also don't know how to deal with Flatpak dependencies, which is why I haven't touched at the current KDE runtime version.